### PR TITLE
Add build metadata (git commit hash and build date) to executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+.PHONY: build clean test help
+
+# Binary name
+BINARY_NAME=go_notes
+
+# Build directory
+BUILD_DIR=./bin
+
+# Get git commit hash
+GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
+
+# Get build date in RFC3339 format
+BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Go build flags
+LDFLAGS=-ldflags "-X main.GitCommit=$(GIT_COMMIT) -X main.BuildDate=$(BUILD_DATE)"
+
+## help: Display this help message
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build the application with build metadata"
+	@echo "  clean       - Remove build artifacts"
+	@echo "  test        - Run tests"
+	@echo "  install     - Build and install to GOPATH/bin"
+	@echo "  version     - Show version information"
+
+## build: Build the application
+build:
+	@echo "Building $(BINARY_NAME)..."
+	@mkdir -p $(BUILD_DIR)
+	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) .
+	@echo "Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
+	@echo "Git Commit: $(GIT_COMMIT)"
+	@echo "Build Date: $(BUILD_DATE)"
+
+## clean: Remove build artifacts
+clean:
+	@echo "Cleaning..."
+	@rm -rf $(BUILD_DIR)
+	@echo "Clean complete"
+
+## test: Run tests
+test:
+	@echo "Running tests..."
+	go test -v ./...
+
+## install: Build and install to GOPATH/bin
+install:
+	@echo "Installing $(BINARY_NAME)..."
+	go install $(LDFLAGS) .
+	@echo "Installation complete"
+
+## version: Show version information
+version:
+	@echo "Git Commit: $(GIT_COMMIT)"
+	@echo "Build Date: $(BUILD_DATE)"

--- a/main.go
+++ b/main.go
@@ -72,7 +72,9 @@ func main() {
 	}
 
 	if optsIntf["v"].(bool) {
-		fmt.Println(app_name, version)
+		fmt.Printf("%s %s\n", app_name, version)
+		fmt.Printf("Git Commit: %s\n", GitCommit)
+		fmt.Printf("Build Date: %s\n", BuildDate)
 		return
 	}
 

--- a/note/web/embeds/notes_list.css
+++ b/note/web/embeds/notes_list.css
@@ -82,6 +82,13 @@ li a:link, li a:visited {
     padding-left: 0.5em
 }
 
+.build-info {
+    font-size: 0.7em;
+    color: #8a8a8a;
+    padding-left: 0.5em;
+    font-style: italic
+}
+
 .note-body {
     padding-left: 1em;
     margin-top: 0.1em

--- a/note/web/notes_list.go
+++ b/note/web/notes_list.go
@@ -49,6 +49,11 @@ func NotesList(w io.Writer, req *http.Request, notes []note.Note, optsStr map[st
 				b.T(" | "),
 				b.AClass("tool", "href", "http://127.0.0.1:"+optsStr["port"]+"/q/all").T("All"),
 				b.T("]"),
+				b.Wrap(func() {
+					if optsStr["git_commit"] != "" && optsStr["git_commit"] != "dev" {
+						b.SpanClass("build-info").T(" | ", optsStr["git_commit"])
+					}
+				}),
 			),
 			b.UlClass("topmost").R(
 				element.ForEach(notes, func(n note.Note) {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,9 @@
+package main
+
+// Build metadata - these variables are set at build time via -ldflags
+var (
+	// GitCommit is the git commit hash
+	GitCommit = "dev"
+	// BuildDate is the build date in RFC3339 format
+	BuildDate = "unknown"
+)

--- a/webserver.go
+++ b/webserver.go
@@ -31,6 +31,10 @@ func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 func webListNotes(w http.ResponseWriter, r *http.Request) {
 	notes := queryNotes()
 
+	// Add build metadata to options
+	optsStr["git_commit"] = GitCommit
+	optsStr["build_date"] = BuildDate
+
 	err := web.NotesList(w, r, notes, optsStr)
 	if err != nil {
 		log.Println("Error in notes list html gen:", err)


### PR DESCRIPTION
- Created version.go with GitCommit and BuildDate variables
- Updated main.go to display build metadata with -v flag
- Created Makefile with build targets that inject metadata via ldflags
- Display git commit hash on web notes list page
- Added CSS styling for build info display